### PR TITLE
Fall back to full page load if new url doesn't have root element

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,9 +89,13 @@ export default function app (selector, routes = ['*']) {
       .then(res => res.text())
       .then(res => {
         const doc = new window.DOMParser().parseFromString(res, 'text/html')
+
+        const newRoot = doc.querySelector(selector)
+        if (! newRoot) return window.location.href = href
+
         const c = [
           doc,
-          doc.querySelector(selector).innerHTML
+          newRoot.innerHTML
         ]
         cache.set(href, c)
         cb && cb(c[0], c[1], route)


### PR DESCRIPTION
Ideally URLs that point to pages on the site without a shared root element would be labeled with the `no-ajax` class and thus not trigger the PJAX behavior. However, sometimes this is missed, and before this PR, these links would simply fail to load (clicking would do nothing). This change allows the load to proceed as a full-page load. It's wasteful because it still triggers the XHR load in between, but at least the site does not break. (Using `no-ajax` is still the right solution to avoid this waste--this is intended only as a failsafe.)